### PR TITLE
Adjust module references to point to this repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/package-url/packageurl-go
+module github.com/anchore/packageurl-go
 
 go 1.12

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/anchore/packageurl-go"
 )
 
 type TestFixture struct {


### PR DESCRIPTION
Based on a [discussion in Slack](https://anchorecommunity.slack.com/archives/C0190NF9TSM/p1632315222000900), we've decided that this fork should stand on its own, without needing to feed back into or depend on the upstream source https://github.com/package-url/packageurl-go, since it appears that the upstream source is no longer being maintained.

In order for our other Go projects to `require` (in `go.mod`) this repository directly, its `go.mod` file must declare the module using its own repository path. This change is implemented via this PR.

**_Important:_** The changes in the PR should not be merged into the upstream source. If an eventual point arrives for these changes to be submitted upstream, this PR should be **reverted** first.