### PR TITLE
Add pub as a valid purl

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -82,13 +82,15 @@ var (
 	TypeNPM = "npm"
 	// TypeNuget is a pkg:nuget purl.
 	TypeNuget = "nuget"
-	// TypeOCI is a pkg:oci purl
+	// TypeOCI is a pkg:oci purl.
 	TypeOCI = "oci"
+	// TypePub is a pkg:pub purl.
+	TypePub = "pub"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
 	// TypeRPM is a pkg:rpm purl.
 	TypeRPM = "rpm"
-	// TypeSwift is pkg:swift purl
+	// TypeSwift is pkg:swift purl.
 	TypeSwift = "swift"
 )
 


### PR DESCRIPTION
As per [this discussion](https://anchorecommunity.slack.com/archives/C019BUXV7R6/p1646337343748709?thread_ts=1646312974.305539&cid=C019BUXV7R6) in Slack, it looks like Dart Support is required.