### PR TITLE
remove npm toLower

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -346,7 +346,7 @@ func FromString(purl string) (PackageURL, error) {
 // See https://github.com/package-url/purl-spec#known-purl-types
 func typeAdjustNamespace(purlType, ns string) string {
 	switch purlType {
-	case TypeBitbucket, TypeDebian, TypeGithub, TypeGolang, TypeNPM, TypeRPM:
+	case TypeBitbucket, TypeDebian, TypeGithub, TypeGolang, TypeRPM:
 		return strings.ToLower(ns)
 	}
 	return ns
@@ -356,7 +356,7 @@ func typeAdjustNamespace(purlType, ns string) string {
 // See https://github.com/package-url/purl-spec#known-purl-types
 func typeAdjustName(purlType, name string) string {
 	switch purlType {
-	case TypeBitbucket, TypeDebian, TypeGithub, TypeGolang, TypeNPM:
+	case TypeBitbucket, TypeDebian, TypeGithub, TypeGolang:
 		return strings.ToLower(name)
 	case TypePyPi:
 		return strings.ToLower(strings.ReplaceAll(name, "_", "-"))


### PR DESCRIPTION
Hi all.
 
While mixed-case package names are no longer allowed to be published to the npm registry, there are over 2800 legacy mixed-case packages, many of which have the same spelling as other existing lowercase packages. See [nice-registry/mixed-case-package-names](https://github.com/nice-registry/mixed-case-package-names) for the the full list.

**Problem:** Packageurl will run `toLower` on caps sensative packages, which is a one way ticket - it will be harder to reference a legacy specific package with out knowing its caps letters) 
**Suggestion:** Remove NPM `toLower` case from library.

Signed-off-by: houdini91 <mdstrauss91@gmail.com>