### PR TITLE
Revert "feat: add dotnet-type (#8)"

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -66,8 +66,6 @@ var (
 	TypeDebian = "deb"
 	// TypeDocker is a pkg:docker purl.
 	TypeDocker = "docker"
-	// TypeDotnet is a pkg:dotnet purl.
-	TypeDotnet = "dotnet"
 	// TypeGem is a pkg:gem purl.
 	TypeGem = "gem"
 	// TypeGeneric is a pkg:generic purl.


### PR DESCRIPTION
This reverts commit a072fa3cb6d7282d17b1641d9b82429fed753657.

The type `dotnet` is invalid currently and should not have been added to our fork.

Related to: https://github.com/anchore/syft/issues/1622