### PR TITLE
Add "+" to characters that need to be escaped

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -380,7 +380,7 @@ func pathEscape(s string) string {
 		switch {
 		case c == '@':
 			t.WriteString("%40")
-		case c == '?' || c == '#' || c == ' ' || c > unicode.MaxASCII:
+		case c == '?' || c == '#' || c == ' ' || c == '+' || c > unicode.MaxASCII:
 			t.WriteString(url.PathEscape(string(c)))
 		default:
 			t.WriteRune(c)


### PR DESCRIPTION
package-url specs explicitly say that version should be percent-encoded. However "+" can be the URL encoding for " ", which conflicts with some purl implementations (e.g. github.com/package-url/packageurl-java), mapping "+" back to " ". The solution is to comply here by percent-encoding "+", as the spec requires it