### PR TITLE
Encode "+" as "%2B" since "+" is a valid SemVer character.

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -380,6 +380,10 @@ func pathEscape(s string) string {
 		switch {
 		case c == '@':
 			t.WriteString("%40")
+		case c == '+':
+			// url.PathEscape doesn't encode '+' since it's a valid query escape character for ' ' in application/x-www-form-urlencoded, but '+' is a
+			// valid character in semver so we don't want it to be unintentionally unescaped as ' ' by downstream parsers of the purl.
+			t.WriteString("%2B")
 		case c == '?' || c == '#' || c == ' ' || c > unicode.MaxASCII:
 			t.WriteString(url.PathEscape(string(c)))
 		default:

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -354,8 +354,8 @@ func TestEncoding(t *testing.T) {
 		},
 		{
 			name:     "pre-encoded version is unchanged",
-			input:    "pkg:type/name/space/name@versio%20n?key=value#sub/path",
-			expected: "pkg:type/name/space/name@versio%20n?key=value#sub/path",
+			input:    "pkg:type/name/space/name@versio%20n%2Bbeta?key=value#sub/path",
+			expected: "pkg:type/name/space/name@versio%20n%2Bbeta?key=value#sub/path",
 		},
 		{
 			name:     "unencoded qualifier value is encoded",


### PR DESCRIPTION
Currently this library is generating PURLs like `pkg:golang/github.com/azure/azure-sdk-for-go@v56.3.0+incompatible`. 

The PURL spec says that versions should be a ["percent-encoded string"](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst), and while the `+` character is fine to use while escaping ` ` for [application/x-www-form-urlencoded content](https://www.w3.org/TR/html401/interact/forms.html), the original [RFC3986 spec for general URIs](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) does not mention using `+` to escape ` `.

I think it's preferable to escape `+` because downstream parsers of the URL will likely unescape the `+` as ` `, resulting in invalid PURL versions as in `pkg:golang/github.com/azure/azure-sdk-for-go@v56.3.0 incompatible`.

There's a good analysis of this problem in https://github.com/package-url/purl-spec/pull/261 as well.

