### PR TITLE
Add Lua Rockspec package type

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -92,6 +92,8 @@ var (
 	TypePub = "pub"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
+	// TypeLuaRock is a pkg:luarock purl.
+	TypeLuaRock = "luarock"
 	// TypeRPM is a pkg:rpm purl.
 	TypeRPM = "rpm"
 	// TypeSwift is pkg:swift purl.


### PR DESCRIPTION
Adds the package manifest format for the Lua language: Rockspec. https://github.com/luarocks/luarocks/wiki/creating-a-rock

Ex: https://github.com/Kong/kong/blob/master/kong-3.7.0-0.rockspec
