### PR TITLE
feat: Add Bitnami type

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -50,6 +50,8 @@ var (
 	TypeAlpine = "apk"
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
+	// TypeBitnami is a pkg:bitnami purl.
+	TypeBitnami = "bitnami"
 	// TypeCocoapods is a pkg:cocoapods purl.
 	TypeCocoapods = "cocoapods"
 	// TypeCargo is a pkg:cargo purl.


### PR DESCRIPTION
### Description of the change

This PR adds "Bitnami" as a valid pURL type given it's a recognized one in the official spec, see:

- https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#bitnami

### Benefits

Golang projects consuming this implementation of the package url spec can use the Bitnami type.

### Possible drawbacks

None