### PR TITLE
fix: plus characters encoded to space

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -558,7 +558,7 @@ func parseQualifiers(rawQuery string) (Qualifiers, error) {
 			continue
 		}
 		key, value, _ := strings.Cut(key, "=")
-		key, err := url.QueryUnescape(key)
+		key, err := url.PathUnescape(key)
 		if err != nil {
 			return nil, fmt.Errorf("error unescaping qualifier key %q", key)
 		}
@@ -567,7 +567,7 @@ func parseQualifiers(rawQuery string) (Qualifiers, error) {
 			return nil, fmt.Errorf("invalid qualifier key: '%s'", key)
 		}
 
-		value, err = url.QueryUnescape(value)
+		value, err = url.PathUnescape(value)
 		if err != nil {
 			return nil, fmt.Errorf("error unescaping qualifier value %q", value)
 		}

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -672,6 +672,11 @@ func TestEncoding(t *testing.T) {
 			input:    "  \tpkg:type/name/space/name@5.2.0\r\n",
 			expected: "pkg:type/name/space/name@5.2.0",
 		},
+		{
+			name:     "plus character not encoded to space",
+			input:    "pkg:type/name@1.0?param=some+thing+with+plus",
+			expected: "pkg:type/name@1.0?param=some%2Bthing%2Bwith%2Bplus",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Qualifiers were incorrectly decoding plus characters (`+`) to spaces (` `), resulting in asymmetric encoding / decoding of certain values. This was due to using `QueryUnescape` instead of `PathUnescape`. I believe [the same problem exists upstream](https://github.com/anchore/packageurl-go/blob/master/packageurl.go#L561-L570), and this would be a good change to try to get accepted there, too.

Once this change is applied to Syft, it will fix: https://github.com/anchore/syft/issues/3533