### PR TITLE
Add candidate type for spack

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -195,6 +195,7 @@ var (
 	TypeEbuild      = "ebuild"
 	TypePuppet      = "puppet"
 	TypeSourceforge = "sourceforge"
+	TypeSpack       = "spack"
 	TypeSublime     = "sublime"
 	TypeTerraform   = "terraform"
 	TypeVagrant     = "vagrant"
@@ -248,6 +249,7 @@ var (
 		TypeEbuild:      {},
 		TypePuppet:      {},
 		TypeSourceforge: {},
+		TypeSpack:       {},
 		TypeSublime:     {},
 		TypeTerraform:   {},
 		TypeVagrant:     {},


### PR DESCRIPTION
spack is currently being considered for inclusion:

https://github.com/package-url/purl-spec/pull/898

---

I am working on adding [spack](https://spack.readthedocs.io) as a scan target for syft and grype. I'd prefer to use an official Go name in the syft package instead of a hard-coded string.

It looks like this repo has diverged from the package-url upstream. Should I also make this same PR there? Are there plans to synchronize?